### PR TITLE
added new inspection for declare(strict_types =1)

### DIFF
--- a/src/main/kotlin/com/vk/kphpstorm/inspections/KphpStrictTypesEnableInspection.kt
+++ b/src/main/kotlin/com/vk/kphpstorm/inspections/KphpStrictTypesEnableInspection.kt
@@ -1,0 +1,44 @@
+package com.vk.kphpstorm.inspections
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.jetbrains.php.lang.documentation.phpdoc.psi.impl.PhpDocCommentImpl
+import com.jetbrains.php.lang.inspections.PhpInspection
+import com.jetbrains.php.lang.psi.elements.Declare
+import com.jetbrains.php.lang.psi.elements.PhpPsiElement
+import com.jetbrains.php.lang.psi.elements.impl.DeclareImpl
+import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor
+import com.vk.kphpstorm.inspections.quickfixes.AddStrictTypesCommentQuickFix
+
+class KphpStrictTypesEnableInspection : PhpInspection() {
+    val strictTypeEnable: CharSequence = "strict_types=1"
+    val kphpTagStrictTypeEnable: CharSequence = "@kphp-strict-types-enabled"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhpElementVisitor() {
+            override fun visitPhpElement(element: PhpPsiElement?) {
+                if (element is Declare && element.text.contains(strictTypeEnable)) {
+                    val psiElements = element.context?.children
+                    if (psiElements != null) {
+                        for (i in psiElements.indices) {
+                            if (i >= 1 && psiElements[i] is DeclareImpl && psiElements[i] == element) {
+                                for (j in i downTo 0) {
+                                    if (psiElements[j] is PhpDocCommentImpl && psiElements[j].text.contains(kphpTagStrictTypeEnable))
+                                        return
+                                }
+                            }
+                        }
+                    }
+
+                    holder.registerProblem(
+                        element,
+                        "Missing @kphp-strict-types-enabled tag",
+                        ProblemHighlightType.WEAK_WARNING,
+                        AddStrictTypesCommentQuickFix(element)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/vk/kphpstorm/inspections/quickfixes/AddStrictTypesCommentQuickFix.kt
+++ b/src/main/kotlin/com/vk/kphpstorm/inspections/quickfixes/AddStrictTypesCommentQuickFix.kt
@@ -1,0 +1,32 @@
+package com.vk.kphpstorm.inspections.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.jetbrains.php.lang.documentation.phpdoc.parser.PhpDocElementTypes
+import com.jetbrains.php.lang.psi.PhpPsiElementFactory
+import com.jetbrains.php.lang.psi.elements.Declare
+
+class AddStrictTypesCommentQuickFix(declare: PsiElement) : LocalQuickFixAndIntentionActionOnPsiElement(declare) {
+
+    override fun getFamilyName() = "Add @kphp-strict-types-enabled tag"
+    override fun getText() = "Add @kphp-strict-types-enabled tag"
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement
+    ) {
+        val declareElement = startElement as Declare
+        val docComment = PhpPsiElementFactory.createFromText(
+            project, PhpDocElementTypes.DOC_COMMENT,
+            "/** @kphp-strict-types-enabled */"
+        )
+
+        declareElement.parent.addBefore(docComment, declareElement)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -34,6 +34,12 @@
                      displayName="PHPDoc checks and simplification"
                      enabledByDefault="false" level="WEAK WARNING"
                      implementationClass="com.vk.kphpstorm.inspections.KphpDocInspection"/>
+
+    <localInspection language="PHP" groupName="KPHPStorm plugin" shortName="KphpStrictTypeEnable"
+                     displayName="Strict type enable checking"
+                     enabledByDefault="false" level="WEAK WARNING"
+                     implementationClass="com.vk.kphpstorm.inspections.KphpStrictTypesEnableInspection"/>
+
     <localInspection language="PHP" groupName="KPHPStorm plugin" shortName="NoTypeDeclarationInspection"
                      displayName="No type declaration"
                      enabledByDefault="false" level="ERROR"

--- a/src/main/resources/inspectionDescriptions/KphpStrictTypeEnable.html
+++ b/src/main/resources/inspectionDescriptions/KphpStrictTypeEnable.html
@@ -1,0 +1,24 @@
+<html lang="en">
+<body>
+Reports missing @kphp-strict-types-enabled comment above the strict_types=1 declaration in a PHP file. This inspection ensures that the necessary KPHP annotation is in place when strict typing is enabled.
+
+<p>
+    In KPHP, it's a best practice to annotate the strict typing feature with a @kphp-strict-types-enabled comment. This provides clarity for developers, helping them understand that strict typing is actively enforced in the current file.
+</p>
+
+<p>
+    For instance, a correct setup would look like:
+</p>
+<pre><code>
+/** @kphp-strict-types-enabled */
+declare(strict_types=1);
+</code></pre>
+
+<!— tooltip end —>
+
+<p>This inspection will highlight the declare(strict_types=1) directive if the corresponding KPHP comment is missing. A quick fix option will be provided to automatically insert the necessary comment.</p>
+
+<p>To adjust the inspection settings or for more details, navigate to settings://$ in the IDE.</p>
+
+</body>
+</html>

--- a/src/test/fixtures/strict_typing/declare_strict_type_enable.fixture.php
+++ b/src/test/fixtures/strict_typing/declare_strict_type_enable.fixture.php
@@ -1,0 +1,3 @@
+<?php
+/** @kphp-strict-types-enabled */
+declare(strict_types=1);

--- a/src/test/fixtures/strict_typing/declare_strict_type_enable_miss.fixture.php
+++ b/src/test/fixtures/strict_typing/declare_strict_type_enable_miss.fixture.php
@@ -1,0 +1,2 @@
+<?php
+<weak_warning descr="Missing @kphp-strict-types-enabled tag">declare(strict_types=1);</weak_warning>

--- a/src/test/kotlin/com/vk/kphpstorm/testing/tests/KphpStrictTypeEnableTagTest.kt
+++ b/src/test/kotlin/com/vk/kphpstorm/testing/tests/KphpStrictTypeEnableTagTest.kt
@@ -1,0 +1,14 @@
+package com.vk.kphpstorm.testing.tests
+
+import com.vk.kphpstorm.inspections.KphpStrictTypesEnableInspection
+import com.vk.kphpstorm.testing.infrastructure.InspectionTestBase
+
+class KphpStrictTypeEnableTagTest : InspectionTestBase(KphpStrictTypesEnableInspection()) {
+    fun `test strict type with tag`() {
+        runFixture("strict_typing/declare_strict_type_enable.fixture.php")
+    }
+
+    fun `test strict type without tag`() {
+        runFixture("strict_typing/declare_strict_type_enable_miss.fixture.php")
+    }
+}


### PR DESCRIPTION
Related with [this](https://github.com/VKCOM/kphpstorm/issues/41) issue:
added new inspection for declare(strict_types=1)
added new QuickFix for declare which adds "@kphp-strict-types-enabled"
added description for this feature (KphpStrictTypeEnable.html)