### PR TITLE
Hidanjkezor/config notification feature

### DIFF
--- a/src/main/kotlin/com/vk/kphpstorm/configuration/KphpStormStartupActivity.kt
+++ b/src/main/kotlin/com/vk/kphpstorm/configuration/KphpStormStartupActivity.kt
@@ -1,5 +1,8 @@
 package com.vk.kphpstorm.configuration
 
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.*
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
@@ -20,7 +23,45 @@ class KphpStormStartupActivity : ProjectActivity {
     }
 
     private fun showSetupDialog(project: Project) {
-        if (!KphpStormConfiguration.wasSetupForProject(project) && KphpStormConfiguration.seemsLikeProjectIsKphpBased(project))
+        if (!KphpStormConfiguration.wasSetupForProject(project) && KphpStormConfiguration.seemsLikeProjectIsKphpBased(project)){
             SetupPluginForProjectDialog(project).show()
+        }else{
+            showNotification(project)
+        }
+    }
+
+    private fun showNotification(project: Project) {
+        val notification = NotificationGroupManager.getInstance()
+            .getNotificationGroup("kphpstorm.plugin.setup.notification")
+            .createNotification("Prototype notification", NotificationType.INFORMATION)
+
+        val propertiesComponent = PropertiesComponent.getInstance(project)
+        if (propertiesComponent.getBoolean("DoNotShowAgain", false)) {
+            return
+        }
+
+        if (propertiesComponent.getBoolean("isKphpProject", false)) {
+            return
+        }
+
+        notification.setSuggestionType(true)
+
+        notification.addAction(object : NotificationAction("Setup project as kPHP") {
+            override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                propertiesComponent.setValue("isKphpProject", true)
+                SetupPluginForProjectDialog(project).show()
+                notification.expire()
+            }
+        })
+
+        // Turn-off notifications
+        notification.addAction(object : NotificationAction("Don`t show it again") {
+            override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                propertiesComponent.setValue("DoNotShowAgain", true)
+                notification.expire()
+            }
+        })
+
+        Notifications.Bus.notify(notification, project)
     }
 }

--- a/src/main/kotlin/com/vk/kphpstorm/configuration/KphpStormStartupActivity.kt
+++ b/src/main/kotlin/com/vk/kphpstorm/configuration/KphpStormStartupActivity.kt
@@ -33,14 +33,17 @@ class KphpStormStartupActivity : ProjectActivity {
     private fun showNotification(project: Project) {
         val notification = NotificationGroupManager.getInstance()
             .getNotificationGroup("kphpstorm.plugin.setup.notification")
-            .createNotification("Prototype notification", NotificationType.INFORMATION)
+            .createNotification("Transforming to kPHP", NotificationType.INFORMATION)
+
+        val dntShow = "DoNotShowAgain"
+        val isKphp = "isKphpProject"
 
         val propertiesComponent = PropertiesComponent.getInstance(project)
-        if (propertiesComponent.getBoolean("DoNotShowAgain", false)) {
+        if (propertiesComponent.getBoolean(dntShow, false)) {
             return
         }
 
-        if (propertiesComponent.getBoolean("isKphpProject", false)) {
+        if (propertiesComponent.getBoolean(isKphp, false)) {
             return
         }
 
@@ -48,7 +51,7 @@ class KphpStormStartupActivity : ProjectActivity {
 
         notification.addAction(object : NotificationAction("Setup project as kPHP") {
             override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-                propertiesComponent.setValue("isKphpProject", true)
+                propertiesComponent.setValue(isKphp, true)
                 SetupPluginForProjectDialog(project).show()
                 notification.expire()
             }
@@ -57,7 +60,7 @@ class KphpStormStartupActivity : ProjectActivity {
         // Turn-off notifications
         notification.addAction(object : NotificationAction("Don`t show it again") {
             override fun actionPerformed(e: AnActionEvent, notification: Notification) {
-                propertiesComponent.setValue("DoNotShowAgain", true)
+                propertiesComponent.setValue(dntShow, true)
                 notification.expire()
             }
         })

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -106,6 +106,10 @@
     <docTagParserExtension tagName="type" implementationClass="com.vk.kphpstorm.exphptype.psi.PhpDocVarTagParserEx" order="first" />
   </extensions>
 
+  <extensions defaultExtensionNs="com.intellij">
+    <notificationGroup id="kphpstorm.plugin.setup.notification" displayType="BALLOON" toolWindowId="kphp configuration notification"/>
+  </extensions>
+
   <actions>
     <group id="com.vk.kphpstorm" text="KPHPStorm" popup="true" icon="/icons/kphp_logo.svg">
       <add-to-group group-id="ToolsMenu" anchor="last"/>


### PR DESCRIPTION
I created notification for kphpStorm about project configuration
For example:
If we have a new project without kPHP we will have suggestion (notification)  to transform PHP project to kPHP 
<img width="363" alt="Notification example" src="https://github.com/VKCOM/kphpstorm/assets/36065987/53b16934-2759-4b92-8649-b2a539eee56f">
