### PR TITLE
version 1.2.15 for PhpStorm 2024.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.2.15] - 31.07.2025
+
+- introduce an intention to add `@kphp-immutable-class` annotation
+
 ## [1.2.14] - 01.03.2024
 
 - adapt code for 2024.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.vk
 pluginName = kphpstorm
 pluginRepositoryUrl = https://github.com/VKCOM/kphpstorm
 # SemVer format -> https://semver.org
-pluginVersion = 1.2.14
+pluginVersion = 1.2.15
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243


### PR DESCRIPTION
As said in `CHANGELOG.md`, the only improvement it an intention to add `@kphp-immutable-class` annotation. The next release, 1.2.15, contains the phpstorm 2025.1 support