### PR TITLE
fix illegal argument exception while PSI nodes creation by stubs

### DIFF
--- a/src/main/kotlin/com/vk/kphpstorm/kphptags/psi/stubs/KphpDocTagStubFactory.kt
+++ b/src/main/kotlin/com/vk/kphpstorm/kphptags/psi/stubs/KphpDocTagStubFactory.kt
@@ -1,0 +1,26 @@
+package com.vk.kphpstorm.kphptags.psi.stubs
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.StubElement
+import com.intellij.psi.stubs.StubElementFactory
+import com.intellij.psi.tree.IElementType
+import com.intellij.util.io.StringRef
+import com.jetbrains.php.lang.documentation.phpdoc.psi.impl.tags.PhpDocTagImpl
+import com.jetbrains.php.lang.documentation.phpdoc.psi.stubs.PhpDocTagStub
+import com.jetbrains.php.lang.documentation.phpdoc.psi.stubs.PhpDocTagStubImpl
+
+@Suppress("UnstableApiUsage")
+class KphpDocTagStubFactory(private val elementType: IElementType) : StubElementFactory<PhpDocTagStub, PhpDocTagImpl> {
+    override fun createStub(psi: PhpDocTagImpl, parentStub: StubElement<out PsiElement>?): PhpDocTagStub {
+        return PhpDocTagStubImpl(
+            parentStub,
+            elementType,
+            StringRef.fromString(psi.name),
+            null
+        )
+    }
+
+    override fun createPsi(stub: PhpDocTagStub): PhpDocTagImpl {
+        return PhpDocTagImpl(stub, stub.elementType)
+    }
+}

--- a/src/main/kotlin/com/vk/kphpstorm/kphptags/psi/stubs/KphpStubRegistryExtension.kt
+++ b/src/main/kotlin/com/vk/kphpstorm/kphptags/psi/stubs/KphpStubRegistryExtension.kt
@@ -3,7 +3,6 @@ package com.vk.kphpstorm.kphptags.psi.stubs
 import com.intellij.psi.stubs.StubRegistry
 import com.intellij.psi.stubs.StubRegistryExtension
 import com.jetbrains.php.lang.documentation.phpdoc.psi.stubs.PhpDocTagStubSerializer
-import com.jetbrains.php.lang.psi.stubs.stub_factories.PhpDocTagStubFactory
 import com.vk.kphpstorm.kphptags.psi.KphpDocElementTypes
 
 @Suppress("UnstableApiUsage")
@@ -38,7 +37,7 @@ class KphpStubRegistryExtension : StubRegistryExtension {
     private fun registerFactories(registry: StubRegistry) {
         registry.registerStubFactory(
             KphpDocElementTypes.kphpDocTagSimple,
-            PhpDocTagStubFactory(KphpDocElementTypes.kphpDocTagSimple)
+            KphpDocTagStubFactory(KphpDocElementTypes.kphpDocTagSimple)
         )
 
         registry.registerStubFactory(
@@ -48,12 +47,12 @@ class KphpStubRegistryExtension : StubRegistryExtension {
 
         registry.registerStubFactory(
             KphpDocElementTypes.kphpDocTagWarnPerformance,
-            PhpDocTagStubFactory(KphpDocElementTypes.kphpDocTagWarnPerformance)
+            KphpDocTagStubFactory(KphpDocElementTypes.kphpDocTagWarnPerformance)
         )
 
         registry.registerStubFactory(
             KphpDocElementTypes.kphpDocTagJson,
-            PhpDocTagStubFactory(KphpDocElementTypes.kphpDocTagJson)
+            KphpDocTagStubFactory(KphpDocElementTypes.kphpDocTagJson)
         )
     }
 }


### PR DESCRIPTION
The problem was unexpected stub handling in the PHP Storm. Now, the custom stub factory was added. It deserializes all simple KPHP tags to the most basic PHP tag node — it seems this fix works